### PR TITLE
Fix a private-in-public error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ enum XDoOperationErrorKind {
 
 /// An error originating from an XDo operation.
 #[derive(Debug)]
-struct XDoOperationError {
+pub struct XDoOperationError {
     kind: XDoOperationErrorKind,
 }
 


### PR DESCRIPTION
Not sure if this crate is abandoned or not, but it was broken by a bugfix in rustc (see https://tools.taskcluster.net/task-inspector/#OeTh_rp2R5aHyWsTGGTaxw/0 and rust-lang/rust#34537 for more details).
Here's a fix.
